### PR TITLE
Feature/subdirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist
 *.egg-info
 *.pyc
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 install:
   - "pip install ."

--- a/homekeeper/util.py
+++ b/homekeeper/util.py
@@ -16,33 +16,39 @@ class cd(object):
     def __exit__(self, etype, value, traceback):
         os.chdir(self.saved_pathname)
 
-def create_symlinks(source_directory, target_directory, excludes=None):
+def create_symlinks(source_directory, target_directory, excludes=None, includes=None):
     """Symlinks files from the dotfiles directory to the home directory.
 
     Args:
         source_directory: The source directory where your dotfiles are.
         target_directory: The target directory for symlinking.
         excludes: An array of files excluded from symlinking.
+        includes: An array of paths in which only the basename gets symlinked
     """
     excludes = excludes if excludes is not None else []
+    includes = includes if includes is not None else []
     if not os.path.isdir(source_directory):
         logging.info('dotfiles directory not found: %s', source_directory)
         return
     logging.info('symlinking files from %s', source_directory)
     with cd(source_directory):
         excludes = set(excludes)
+        includes = set(includes)
         for pathname in os.listdir('.'):
             basename = os.path.basename(pathname)
             if basename in excludes:
                 continue
+            # Our source and target are set, unless basename matches something
+            # within our include path, then basneame becomes include
+            for include in includes:
+                (inc_path, inc_base) = os.path.split(include)
+                if (os.path.commonprefix([basename,include])):
+                    basename = include
             source = os.path.join(source_directory, basename)
             target = os.path.join(target_directory, basename)
-            if os.path.islink(target):
-                os.unlink(target)
-            if os.path.isfile(target):
-                os.remove(target)
-            if os.path.isdir(target):
-                shutil.rmtree(target)
+
+            cleanup_target(target)
+
             os.symlink(source, target)
             logging.info('symlinked %s -> %s', target, source)
 
@@ -60,4 +66,21 @@ def cleanup_symlinks(directory):
             continue
         logging.info('removing broken link: %s', pathname)
         os.unlink(pathname)
+
+# TODO: remove_original(target)
+def cleanup_target(target):
+    """Cleans up target path before we link to it.
+
+    Args:
+        target: Path of symlink target, can be file or directory
+    """
+    if os.path.islink(target):
+        os.unlink(target)
+        logging.info('removed symlink %s', target)
+    if os.path.isfile(target):
+        os.remove(target)
+        logging.info('removed file %s', target)
+    if os.path.isdir(target):
+        shutil.rmtree(target)
+        logging.info('removed directory %s', target)
 

--- a/homekeeper/util.py
+++ b/homekeeper/util.py
@@ -16,7 +16,8 @@ class cd(object):
     def __exit__(self, etype, value, traceback):
         os.chdir(self.saved_pathname)
 
-def create_symlinks(source_directory, target_directory, excludes=None, includes=None):
+def create_symlinks(
+        source_directory, target_directory, excludes=None, includes=None):
     """Symlinks files from the dotfiles directory to the home directory.
 
     Args:
@@ -41,8 +42,7 @@ def create_symlinks(source_directory, target_directory, excludes=None, includes=
             # Our source and target are set, unless basename matches something
             # within our include path, then basneame becomes include
             for include in includes:
-                (inc_path, inc_base) = os.path.split(include)
-                if (os.path.commonprefix([basename,include])):
+                if os.path.commonprefix([basename, include]):
                     basename = include
             source = os.path.join(source_directory, basename)
             target = os.path.join(target_directory, basename)
@@ -67,7 +67,6 @@ def cleanup_symlinks(directory):
         logging.info('removing broken link: %s', pathname)
         os.unlink(pathname)
 
-# TODO: remove_original(target)
 def cleanup_target(target):
     """Cleans up target path before we link to it.
 

--- a/homekeeper/util_test.py
+++ b/homekeeper/util_test.py
@@ -6,6 +6,7 @@ import unittest
 os = None
 create_symlinks = homekeeper.util.create_symlinks
 cleanup_symlinks = homekeeper.util.cleanup_symlinks
+cleanup_target  = homekeeper.util.cleanup_target
 testing = homekeeper.testing
 
 class UtilTest(unittest.TestCase):
@@ -40,6 +41,20 @@ class UtilTest(unittest.TestCase):
         self.assertFalse(os.path.exists(target))
         self.assertFalse(os.path.islink(target))
 
+    def test_create_symlinks_with_includes(self):
+        source = '/dotfiles/.config/Terminal/terminalrc'
+        target = self.home + '/.config/Terminal/terminalrc'
+        includes = ['.config/Terminal/terminalrc']
+        self.filesystem.CreateFile(source)
+        self.assertTrue(os.path.exists(source))
+        self.assertFalse(os.path.exists(target))
+        create_symlinks('/dotfiles', self.home, excludes=None, includes=includes)
+        self.assertTrue(os.path.exists(source)) # source exists?
+        self.assertTrue(os.path.exists(target)) # target exists?
+        # target parent dir is still a dir
+        self.assertTrue(os.path.isdir(os.path.dirname(target))) 
+        self.assertTrue(os.path.islink(target)) # target is link?
+
     def test_cleanup_symlinks(self):
         self.filesystem.CreateFile('/a.txt')
         os.symlink('/a.txt', '/exists.txt')
@@ -51,4 +66,11 @@ class UtilTest(unittest.TestCase):
         self.assertFalse(os.path.exists('/nonexistent1.txt'))
         self.assertFalse(os.path.exists('/nonexistent2.txt'))
         self.assertTrue(os.path.exists('/exists.txt'))
+
+    def test_cleanup_target(self):
+        target = self.home + '/.vimrc'
+        self.filesystem.CreateFile(target)
+        self.assertTrue(os.path.exists(target))
+        cleanup_target(target)
+        self.assertFalse(os.path.exists(target))
 

--- a/homekeeper/util_test.py
+++ b/homekeeper/util_test.py
@@ -6,7 +6,7 @@ import unittest
 os = None
 create_symlinks = homekeeper.util.create_symlinks
 cleanup_symlinks = homekeeper.util.cleanup_symlinks
-cleanup_target  = homekeeper.util.cleanup_target
+cleanup_target = homekeeper.util.cleanup_target
 testing = homekeeper.testing
 
 class UtilTest(unittest.TestCase):
@@ -48,11 +48,13 @@ class UtilTest(unittest.TestCase):
         self.filesystem.CreateFile(source)
         self.assertTrue(os.path.exists(source))
         self.assertFalse(os.path.exists(target))
-        create_symlinks('/dotfiles', self.home, excludes=None, includes=includes)
+        create_symlinks(
+            '/dotfiles', self.home,
+            excludes=None, includes=includes)
         self.assertTrue(os.path.exists(source)) # source exists?
         self.assertTrue(os.path.exists(target)) # target exists?
         # target parent dir is still a dir
-        self.assertTrue(os.path.isdir(os.path.dirname(target))) 
+        self.assertTrue(os.path.isdir(os.path.dirname(target)))
         self.assertTrue(os.path.islink(target)) # target is link?
 
     def test_cleanup_symlinks(self):


### PR DESCRIPTION
# Description
Normally homekeeper does an "rm" of existing target files before linking out
of your dotfiles dir.  In some cases, like (ex. '~/.config') one may want to
keep some of the subdirectories under src control and leave the others alone.
Paths like this can be listed in 'includes', at which point homekeeper will
leave the basepath alone and attempt to symlink only the 'subpath'.

# Example
```
source: ${dotfiles}/base/.config/Terminal/terminalrc
target: ${HOME}/.config/Terminal/terminalrc
```

homekeeper **should not** `rm` the whole of `${HOME}/.config`, we only 
want the n-th level path linked.